### PR TITLE
Fix broken cli tests and move cli tests to the right subpackage

### DIFF
--- a/sml_sync/cli/tests/test_cli.py
+++ b/sml_sync/cli/tests/test_cli.py
@@ -5,10 +5,10 @@ from unittest.mock import patch
 
 import pytest
 
-from .. import cli
+from ... import cli
 from .. import models
-from ..cli.config import FileConfiguration
-from ..cli.projects import Project
+from ..config import FileConfiguration
+from ..projects import Project
 
 
 @contextmanager

--- a/sml_sync/cli/tests/test_config.py
+++ b/sml_sync/cli/tests/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from ..cli.config import get_config, FileConfiguration
+from ..config import get_config, FileConfiguration
 
 
 # Note that, for compatibility with Python3.5, the local directory


### PR DESCRIPTION
Moving the cli modules to a subpackage had broken an import path: it was looking for `Configuration` in `models`, rather than in `cli.models`.

This fixes that by moving cli tests to `/cli/tests/`, rather than just `/tests/`. I think having a separate subdirectory for each subpackage is more common (e.g. https://github.com/scikit-learn/scikit-learn/tree/master/sklearn/ensemble, https://github.com/scipy/scipy/tree/master/scipy/constants)