### PR TITLE
Use dependency links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ environment.
 To install, just type this in a terminal on your laptop:
 
 ```
-$ curl https://bitbucket.org/theasi/sml-sync/raw/0.2.3/install.sh | bash
+pip install https://github.com/ASIDataScience/sml-sync/archive/0.2.3.zip --process-dependency-links
 ```
 
 Getting started

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,17 @@ setup(
     entry_points={
         'console_scripts': ['sml-sync=sml_sync:run']
     },
+    # prompt_toolkit 2.0 is currently only available from github:
+    dependency_links = ['https://github.com/'
+                        + 'jonathanslenders/python-prompt-toolkit/'
+                        + 'tarball/2.0#egg=prompt_toolkit-2.0'],
     install_requires=[
         'sml',
         'daiquiri',
         'paramiko',
         'inflect',
         'watchdog',
-        'semantic_version'
-        # This is currently missing prompt-toolkit
-        # (waiting for 2.0 to be released)
+        'semantic_version',
+        'prompt_toolkit>=2.0'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setup(
         'console_scripts': ['sml-sync=sml_sync:run']
     },
     # prompt_toolkit 2.0 is currently only available from github:
-    dependency_links = ['https://github.com/'
-                        + 'jonathanslenders/python-prompt-toolkit/'
-                        + 'tarball/2.0#egg=prompt_toolkit-2.0'],
+    dependency_links=['https://github.com/'
+                      'jonathanslenders/python-prompt-toolkit/'
+                      'tarball/2.0#egg=prompt_toolkit-2.0'],
     install_requires=[
         'sml',
         'daiquiri',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version=version_ns['version'],
     description='SherlockML file synchronizer',
     author='ASI Data Science',
-    packages=['sml_sync', 'sml_sync.screens'],
+    packages=['sml_sync', 'sml_sync.screens', 'sml_sync.cli'],
     entry_points={
         'console_scripts': ['sml-sync=sml_sync:run']
     },

--- a/sml_sync/version.py
+++ b/sml_sync/version.py
@@ -1,3 +1,3 @@
 
-__version__ = '0.2.4-alpha2'
+__version__ = '0.2.4-alpha3'
 version = __version__

--- a/sml_sync/version.py
+++ b/sml_sync/version.py
@@ -1,3 +1,3 @@
 
-__version__ = '0.2.3'
+__version__ = '0.2.4-alpha2'
 version = __version__


### PR DESCRIPTION
Adds prompt_toolkit to setup.py dependencies and a link to the github of prompt_toolkit to install the dev version of it.