### PR TITLE
Add mypy annotations for screens.components subpackage

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,10 @@
 [mypy]
 mypy_path = stubs
 
+[mypy-sml_sync.screens.components.*]
+disallow_any_unimported = True
+disallow_untyped_defs = True
+
 [mypy-sml_sync.screens.components.tests.*]
 # Don't typecheck tests yet
 ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,28 @@
+[mypy]
+mypy_path = stubs
+
+[mypy-sml_sync.screens.components.tests.*]
+# Don't typecheck tests yet
+ignore_errors = True
+
+# Dependencies that don't have stubs yet
+[mypy-sml.*]
+ignore_missing_imports = True
+
+[mypy-watchdog.*]
+ignore_missing_imports = True
+
+[mypy-semantic-versions.*]
+ignore_missing_imports = True
+
+[mypy-daiquiri]
+ignore_missing_imports = True
+
+[mypy-semantic_version]
+ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-paramiko]
+ignore_missing_imports = True

--- a/sml_sync/screens/choose_remote_dir.py
+++ b/sml_sync/screens/choose_remote_dir.py
@@ -7,11 +7,9 @@ import time
 from enum import Enum
 from queue import Empty, Queue
 
-from prompt_toolkit.application.current import get_app
+from prompt_toolkit.application import get_app
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import HSplit, VSplit
-from prompt_toolkit.layout.containers import Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout import HSplit, VSplit, Window, FormattedTextControl
 from prompt_toolkit.widgets import TextArea
 
 from ..pubsub import Messages

--- a/sml_sync/screens/components/table.py
+++ b/sml_sync/screens/components/table.py
@@ -6,7 +6,9 @@ from typing import List, Optional
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.document import Document
 from prompt_toolkit.layout import (
-    Window, HSplit, FormattedTextControl, BufferControl, ScrollbarMargin)
+    Window, HSplit, FormattedTextControl, BufferControl, ScrollbarMargin,
+    Container
+)
 
 
 class Alignment(Enum):
@@ -27,7 +29,7 @@ class TableColumn(
             cls, rows: List[str],
             header: str,
             settings: Optional[ColumnSettings] = None
-    ):
+    ) -> 'TableColumn':
         if settings is None:
             settings = ColumnSettings()
         return super(TableColumn, cls).__new__(cls, rows, header, settings)
@@ -57,14 +59,19 @@ class Table(object):
             self._body_windows(formatted_columns)
         )
 
-    def _get_column_width(self, column):
+    def _get_column_width(self, column: TableColumn) -> int:
         width = max(
             len(column.header),
             max((len(row) for row in column.rows), default=0)
         )
         return width
 
-    def _format_cell(self, content, column_settings, width):
+    def _format_cell(
+            self,
+            content: str,
+            column_settings: ColumnSettings,
+            width: int
+    ) -> str:
         if column_settings.alignment == Alignment.LEFT:
             return content.ljust(width)
         else:
@@ -101,5 +108,5 @@ class Table(object):
             body_windows = []
         return body_windows
 
-    def __pt_container__(self):
+    def __pt_container__(self) -> Container:
         return self.window

--- a/sml_sync/screens/components/table.py
+++ b/sml_sync/screens/components/table.py
@@ -16,7 +16,7 @@ class Alignment(Enum):
 
 class ColumnSettings(object):
 
-    def __init__(self, alignment=Alignment.LEFT):
+    def __init__(self, alignment: Alignment = Alignment.LEFT) -> None:
         self.alignment = alignment
 
 
@@ -35,7 +35,7 @@ class TableColumn(
 
 class Table(object):
 
-    def __init__(self, columns: List[TableColumn], sep: str = ' '):
+    def __init__(self, columns: List[TableColumn], sep: str = ' ') -> None:
         if len(set(len(column.rows) for column in columns)) not in {0, 1}:
             raise ValueError('All columns must have the same number of rows.')
 
@@ -70,7 +70,7 @@ class Table(object):
         else:
             return content.rjust(width)
 
-    def _header_windows(self, formatted_headers):
+    def _header_windows(self, formatted_headers: List[str]) -> List[Window]:
         if len(formatted_headers):
             header_control = FormattedTextControl(
                 self._sep.join(formatted_headers))
@@ -79,13 +79,16 @@ class Table(object):
             header_windows = [Window(height=1, width=0)]
         return header_windows
 
-    def _body_windows(self, formatted_columns):
+    def _body_windows(
+            self,
+            formatted_columns: List[List[str]]
+    ) -> List[Window]:
         rows = list(itertools.zip_longest(*formatted_columns, fillvalue=''))
         if rows:
             rows_string = [self._sep.join(row) for row in rows]
             table_body = '\n'.join(rows_string)
 
-            document = Document(table_body, 0)
+            document = Document(table_body, cursor_position=0)
             _buffer = Buffer(document=document, read_only=True)
             self._body_control = BufferControl(_buffer)
             body_windows = [

--- a/sml_sync/screens/components/table.py
+++ b/sml_sync/screens/components/table.py
@@ -101,17 +101,5 @@ class Table(object):
             body_windows = []
         return body_windows
 
-    def preferred_width(self, max_available_width):
-        return self.window.preferred_width(max_available_width)
-
-    def preferred_height(self, width, max_available_height):
-        return self.window.preferred_height(width, max_available_height)
-
-    def write_to_screen(self, *args, **kwargs):
-        return self.window.write_to_screen(*args, **kwargs)
-
-    def get_children(self):
-        return self.window.get_children()
-
     def __pt_container__(self):
         return self.window

--- a/sml_sync/screens/components/tests/test_table.py
+++ b/sml_sync/screens/components/tests/test_table.py
@@ -1,3 +1,4 @@
+
 import textwrap
 
 import pytest

--- a/sml_sync/screens/components/tests/test_vertical_menu.py
+++ b/sml_sync/screens/components/tests/test_vertical_menu.py
@@ -1,4 +1,3 @@
-
 from unittest.mock import Mock
 
 from prompt_toolkit.layout import to_container

--- a/sml_sync/screens/components/vertical_menu.py
+++ b/sml_sync/screens/components/vertical_menu.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from typing import List, Optional, Any, Callable
 
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import Window, FormattedTextControl
+from prompt_toolkit.layout import Window, FormattedTextControl, Container
 
 MenuEntry = namedtuple('MenuEntry', ['id_', 'text'])
 
@@ -44,30 +44,30 @@ class VerticalMenu(object):
     ) -> None:
         self._menu_change_callbacks.append(callback)
 
-    def _execute_callbacks(self, new_selection):
+    def _execute_callbacks(self, new_selection: Any) -> None:
         for callback in self._menu_change_callbacks:
             callback(new_selection)
 
-    def _select_next(self):
+    def _select_next(self) -> None:
         self._set_selection_index(self._current_index + 1)
 
-    def _select_previous(self):
+    def _select_previous(self) -> None:
         self._set_selection_index(self._current_index - 1)
 
-    def _get_key_bindings(self):
+    def _get_key_bindings(self) -> KeyBindings:
         bindings = KeyBindings()
 
-        @bindings.add('up')  # noqa: F811
-        def _(event):
+        @bindings.add('up')
+        def up_key(event: Any) -> None:
             self._select_previous()
 
-        @bindings.add('down')  # noqa: F811
-        def _(event):
+        @bindings.add('down')
+        def down_key(event: Any) -> None:
             self._select_next()
 
         return bindings
 
-    def _set_selection_index(self, new_index):
+    def _set_selection_index(self, new_index: int) -> None:
         if self._entries:
             new_index = new_index % len(self._entries)
             if self._current_index != new_index:
@@ -75,14 +75,14 @@ class VerticalMenu(object):
                 self._set_control_text()
                 self._execute_callbacks(self.current_selection)
 
-    def _set_control_text(self):
+    def _set_control_text(self) -> None:
         control_lines = []
         for ientry, entry in enumerate(self._formatted_entries):
             style = 'reverse' if ientry == self._current_index else ''
             control_lines.append((style, entry + '\n'))
         self._control.text = control_lines
 
-    def __pt_container__(self):
+    def __pt_container__(self) -> Container:
         return self._window
 
 

--- a/sml_sync/screens/components/vertical_menu.py
+++ b/sml_sync/screens/components/vertical_menu.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-from typing import List, Optional
+from typing import List, Optional, Any, Callable
 
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import Window, FormattedTextControl
@@ -10,7 +10,11 @@ MenuEntry = namedtuple('MenuEntry', ['id_', 'text'])
 
 class VerticalMenu(object):
 
-    def __init__(self, entries: List[MenuEntry], width: Optional[int]=None):
+    def __init__(
+            self,
+            entries: List[MenuEntry],
+            width: Optional[int] = None
+    ) -> None:
         self._current_index = 0
         self._entries = entries
         if width is None:
@@ -24,17 +28,20 @@ class VerticalMenu(object):
             key_bindings=self._get_key_bindings())
         self._set_control_text()
         self._window = Window(self._control, width=width)
-        self._menu_change_callbacks = []
+        self._menu_change_callbacks: List[Callable[[Any], None]] = []
 
     @property
-    def current_selection(self):
+    def current_selection(self) -> Any:
         if self._entries:
             return self._entries[self._current_index].id_
         else:
             # No items in the menu
             return None
 
-    def register_menu_change_callback(self, callback):
+    def register_menu_change_callback(
+            self,
+            callback: Callable[[Any], None]
+    ) -> None:
         self._menu_change_callbacks.append(callback)
 
     def _execute_callbacks(self, new_selection):
@@ -79,7 +86,7 @@ class VerticalMenu(object):
         return self._window
 
 
-def _ensure_width(inp: str, width: int):
+def _ensure_width(inp: str, width: int) -> str:
     """
     Ensure that string `inp` is exactly `width` characters long.
     """

--- a/sml_sync/screens/diff.py
+++ b/sml_sync/screens/diff.py
@@ -2,11 +2,12 @@
 import logging
 from enum import Enum
 
-from prompt_toolkit.application.current import get_app
+from prompt_toolkit.application import get_app
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import HSplit, VSplit, to_container
-from prompt_toolkit.layout.containers import FloatContainer, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout import (
+    HSplit, VSplit, to_container, FloatContainer, Window,
+    FormattedTextControl
+)
 from prompt_toolkit.widgets import TextArea, VerticalLine
 
 from ..pubsub import Messages

--- a/sml_sync/screens/help.py
+++ b/sml_sync/screens/help.py
@@ -1,7 +1,5 @@
 
-from prompt_toolkit.layout import HSplit
-from prompt_toolkit.layout.containers import Float, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout import HSplit, Window, FormattedTextControl, Float
 from prompt_toolkit.widgets import Frame
 
 

--- a/sml_sync/screens/sync.py
+++ b/sml_sync/screens/sync.py
@@ -3,10 +3,8 @@ import threading
 import time
 from enum import Enum
 
-from prompt_toolkit.application.current import get_app
-from prompt_toolkit.layout import HSplit
-from prompt_toolkit.layout.containers import Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.application import get_app
+from prompt_toolkit.layout import HSplit, Window, FormattedTextControl
 
 from .base import BaseScreen
 from .loading import LoadingIndicator

--- a/sml_sync/screens/walking_trees.py
+++ b/sml_sync/screens/walking_trees.py
@@ -3,10 +3,8 @@ import threading
 import time
 from enum import Enum
 
-from prompt_toolkit.application.current import get_app
-from prompt_toolkit.layout import HSplit
-from prompt_toolkit.layout.containers import Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.application import get_app
+from prompt_toolkit.layout import HSplit, Window, FormattedTextControl
 
 from ..pubsub import Messages
 from .base import BaseScreen

--- a/sml_sync/screens/watch_sync.py
+++ b/sml_sync/screens/watch_sync.py
@@ -4,11 +4,11 @@ import threading
 import time
 from datetime import datetime
 
-from prompt_toolkit.application.current import get_app
+from prompt_toolkit.application import get_app
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import HSplit, VSplit
-from prompt_toolkit.layout.containers import FloatContainer, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout import (
+    HSplit, VSplit, FloatContainer, Window, FormattedTextControl
+)
 
 from . import humanize
 from ..models import ChangeEventType

--- a/sml_sync/ui.py
+++ b/sml_sync/ui.py
@@ -4,9 +4,7 @@ import traceback
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
-from prompt_toolkit.layout import HSplit, Layout
-from prompt_toolkit.layout.containers import Window
-from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout import HSplit, Layout, Window, FormattedTextControl
 
 from .pubsub import Messages
 

--- a/stubs/prompt_toolkit/application.pyi
+++ b/stubs/prompt_toolkit/application.pyi
@@ -1,0 +1,6 @@
+
+class Application(object):
+    pass
+
+
+def get_app() -> Application: ...

--- a/stubs/prompt_toolkit/buffer.pyi
+++ b/stubs/prompt_toolkit/buffer.pyi
@@ -1,0 +1,13 @@
+
+from typing import Optional
+
+from .document import Document
+
+
+class Buffer(object):
+
+    def __init__(
+            self,
+            document: Optional[Document] = None,
+            read_only: bool = False
+    ) -> None: ...

--- a/stubs/prompt_toolkit/document.pyi
+++ b/stubs/prompt_toolkit/document.pyi
@@ -1,0 +1,10 @@
+
+from typing import Optional
+
+
+class Document(object):
+
+    def __init__(
+            self,
+            text: str = '',
+            cursor_position: Optional[int] = None) -> None: ...

--- a/stubs/prompt_toolkit/key_binding.pyi
+++ b/stubs/prompt_toolkit/key_binding.pyi
@@ -1,0 +1,13 @@
+
+from typing import List
+
+
+class KeyBindingsBase(object):
+    pass
+
+
+class KeyBindings(KeyBindingsBase):
+    def __init__(self) -> None: ...
+
+
+def merge_key_bindings(bindings: List[KeyBindings]) -> KeyBindingsBase: ...

--- a/stubs/prompt_toolkit/key_binding.pyi
+++ b/stubs/prompt_toolkit/key_binding.pyi
@@ -1,5 +1,5 @@
 
-from typing import List
+from typing import List, Callable, Any
 
 
 class KeyBindingsBase(object):
@@ -8,6 +8,8 @@ class KeyBindingsBase(object):
 
 class KeyBindings(KeyBindingsBase):
     def __init__(self) -> None: ...
+
+    def add(self, key: str) -> Callable[..., Any]: ...
 
 
 def merge_key_bindings(bindings: List[KeyBindings]) -> KeyBindingsBase: ...

--- a/stubs/prompt_toolkit/layout.pyi
+++ b/stubs/prompt_toolkit/layout.pyi
@@ -1,5 +1,5 @@
 
-from typing import Optional, Any, List, Iterable
+from typing import Optional, Any, List, Iterable, Union, Tuple
 
 from .key_binding import KeyBindings
 from .buffer import Buffer
@@ -12,9 +12,11 @@ class UIControl(object):
 
 class FormattedTextControl(UIControl):
 
+    text: Union[str, List[Tuple[str, str]]]
+
     def __init__(
             self,
-            text: str,
+            text: Union[str, List[Tuple[str, str]]],
             focusable: bool = False,
             show_cursor: bool = False,
             key_bindings: Optional[KeyBindings] = None) -> None: ...

--- a/stubs/prompt_toolkit/layout.pyi
+++ b/stubs/prompt_toolkit/layout.pyi
@@ -1,0 +1,110 @@
+
+from typing import Optional, Any, List, Iterable
+
+from .key_binding import KeyBindings
+from .buffer import Buffer
+
+
+class UIControl(object):
+
+    def reset(self) -> None: ...
+
+
+class FormattedTextControl(UIControl):
+
+    def __init__(
+            self,
+            text: str,
+            focusable: bool = False,
+            show_cursor: bool = False,
+            key_bindings: Optional[KeyBindings] = None) -> None: ...
+
+
+class BufferControl(UIControl):
+
+    def __init__(
+            self,
+            buffer: Optional[Buffer] = None
+    ) -> None: ...
+
+
+class Margin(object):
+    pass
+
+
+class ScrollbarMargin(Margin):
+
+    def __init__(self, display_arrows: int = 2) -> None: ...
+
+
+class Container(object):
+
+    def reset(self) -> None: ...
+
+    def preferred_width(self, max_available_width: int) -> int: ...
+
+    def preferred_height(
+            self,
+            width: int,
+            max_available_height: int
+    ) -> int: ...
+
+
+class Window(Container):
+
+    def __init__(
+            self,
+            content: Optional[UIControl] = None,
+            width: Optional[int] = None,
+            height: Optional[int] = None,
+            left_margins: Optional[Iterable[Margin]] = None,
+            right_margins: Optional[Iterable[Margin]] = None
+    ) -> None: ...
+
+
+class HSplit(Container):
+
+    def __init__(
+            self,
+            children: List[Any],
+            width: Optional[int] = None,
+            height: Optional[int] = None
+    ) -> None: ...
+
+
+class VSplit(Container):
+
+    def __init__(
+            self,
+            children: List[Any],
+            width: Optional[int] = None,
+            height: Optional[int] = None
+    ) -> None: ...
+
+
+class Float(object):
+
+    def __init__(
+            self,
+            content: Optional[Container]
+    ) -> None: ...
+
+
+class FloatContainer(Container):
+
+    def __init__(
+            self,
+            content: Container,
+            floats: Iterable[Float]
+    ) -> None: ...
+
+
+def to_container(container: Any) -> Container: ...
+
+
+class Layout(object):
+
+    def __init__(
+            self,
+            container: Container
+    ) -> None: ...

--- a/stubs/prompt_toolkit/widgets.pyi
+++ b/stubs/prompt_toolkit/widgets.pyi
@@ -1,0 +1,16 @@
+
+from .layout import Container
+
+
+class TextArea(object):
+
+    def __init__(self, text: str = '') -> None: ...
+
+
+class Frame(object):
+
+    def __init__(self, body: Container) -> None: ...
+
+
+class VerticalLine(object):
+    pass


### PR DESCRIPTION
This is an attempt at introducing greater rigour in how we use mypy types. This PR is mostly supposed to be a starting point for discussions, not necessarily useful in itself.

The `sml_sync.screens.components` subpackage now has full typechecking, including on all private methods. This subpackage heavily dependent on prompt_toolkit, which doesn't have type annotations, so I've written some stubs by just reading the code on GitHub.

This exercise has lead to some tidying of import structures (we were frequently importing classes from `prompt_toolkit.layout.containers` or `prompt_toolkit.layout.controls`, instead of directly from `prompt_toolkit.layout`, for instance), so it's been somewhat beneficial for the codebase. Nevertheless, type annotations do add complexity, so I'm open to deciding we don't want these.

If we do decide to merge this, we should test it in Travis.

To reproduce, run:

```
mypy sml_sync
```