### PR TITLE
Get prompt_tookit from PyPi rather than from GitHub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ paramiko
 inflect
 watchdog
 semantic_version
-git+https://github.com/jonathanslenders/python-prompt-toolkit@2.0
+prompt_toolkit >= 2.0

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,6 @@ setup(
     entry_points={
         'console_scripts': ['sml-sync=sml_sync:run']
     },
-    # prompt_toolkit 2.0 is currently only available from github:
-    dependency_links=['https://github.com/'
-                      'jonathanslenders/python-prompt-toolkit/'
-                      'tarball/2.0#egg=prompt_toolkit-2.0'],
     install_requires=[
         'sml',
         'daiquiri',


### PR DESCRIPTION
Now that Python prompt toolkit version 2.0 is available on Pypi, we can install from there, rather than from GitHub.