### PR TITLE
Get list of versions from PyPI instead of bitbucket

### DIFF
--- a/sml_sync/update.py
+++ b/sml_sync/update.py
@@ -1,6 +1,5 @@
 """Prompt the user to update sml-sync"""
 
-import errno
 import json
 import os
 import time

--- a/sml_sync/update.py
+++ b/sml_sync/update.py
@@ -8,9 +8,8 @@ from urllib.request import urlopen
 import daiquiri
 import semantic_version
 
-from .version import version
 from .dirs import ensure_parent_exists
-
+from .version import version
 
 PYPI_JSON_URL = 'https://pypi.org/pypi/sml_sync/json'
 

--- a/sml_sync/update.py
+++ b/sml_sync/update.py
@@ -13,7 +13,7 @@ from .version import version
 from .dirs import ensure_parent_exists
 
 
-TAGS_URL = 'https://api.bitbucket.org/2.0/repositories/theasi/sml-sync/refs/tags?pagelen=100'  # noqa
+PYPI_JSON_URL = 'https://pypi.org/pypi/sml_sync/json'
 
 LOGGER = daiquiri.getLogger('version-check')
 
@@ -41,22 +41,14 @@ def _is_full_release(version):
 
 def _get_versions():
 
-    # Get to the last page of tags
+    # get the json feed
     versions = []
-    with urlopen(TAGS_URL, timeout=5) as response:
+    with urlopen(PYPI_JSON_URL, timeout=5) as response:
         json_response = json.load(response)
-        versions.extend([
-            semantic_version.Version(tag['name'])
-            for tag in json_response['values']
-        ])
-    while 'next' in json_response:
-        next_url = json_response['next']
-        with urlopen(next_url, timeout=5) as response:
-            json_response = json.load(response)
-            versions.extend([
-                semantic_version.Version(tag['name'])
-                for tag in json_response['values']
-            ])
+
+    versions = [semantic_version.Version(version)
+                for version in json_response['releases'].keys()
+                if _is_full_release(semantic_version.Version(version))]
 
     # Exclude release candidates and alpha releases
     full_versions = [

--- a/sml_sync/update.py
+++ b/sml_sync/update.py
@@ -69,7 +69,7 @@ def _check_for_new_release():
             "You are using sml-sync version {current}, however "
             "version {latest} is available.\n"
             "You should upgrade with:\n\n"
-            "curl https://bitbucket.org/theasi/sml-sync/raw/{latest}/install.sh | bash"  # noqa
+            "pip install -U sml-sync"
         )
         print(template.format(current=current, latest=latest))
     _set_mtime(_last_update_path())


### PR DESCRIPTION
This checks released versions on PyPI instead of Bitbucket. Everything else is untouched!