### PR TITLE
Add `--project` flag in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then, in a terminal on  *your laptop*, head to `~/oss/gmaps` and run:
 
 ```
 $ cd ~/oss/gmaps
-$ sml-sync jupyter-gmaps
+$ sml-sync --project jupyter-gmaps
 ```
 
 You will be prompted for a remote directory. Choose `/project/gmaps`. *sml-sync*
@@ -78,7 +78,7 @@ with a list of path patterns. For instance, to ignore anything under `dist/`
 and `/docs/build`, run `sml-sync` with:
 
 ```
-$ sml-sync jupyter-gmaps --ignore dist/ docs/build/
+$ sml-sync --project jupyter-gmaps --ignore dist/ docs/build/
 ```
 
 You can pass shell glob-like patterns to `--ignore`. Some common patterns are


### PR DESCRIPTION
The project argument was previously changed from being a positional argument to an optional argument, which can be specified in the configuration file, however the instructions in the README still show it as a positional argument.