### PR TITLE
Specify the minimum Python version as 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ You need a version of `rsync`. I have tested this with `rsync 2.6.9` and
 `3.1.1`. This has only really been tested on macOS and Ubuntu 16.04. It will
 almost certainly not work on Windows.
 
-You will need Python 3. I recommend installing *sml-sync* in a virtual
-environment.
+You will need Python 3.5 or later. I recommend installing *sml-sync* in a
+virtual environment.
 
 To install, just type this in a terminal on your laptop:
 

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,10 @@ setup(
         'watchdog',
         'semantic_version',
         'prompt_toolkit>=2.0'
+    ],
+    classifiers=[
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
     ]
+
 )


### PR DESCRIPTION
Document that `sml-sync` requires Python 3.5 or later, because it uses the `typing` module and syntax only introduced in 3.5.