### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language:
+  python
+python:
+  - "3.5"
+  - "3.6"
+install:
+  - "pip install -U pip"
+  - "pip install -r requirements.txt"
+  - "pip install pytest"
+script:
+  py.test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 SherlockML incremental synchronization
 ======================================
 
+[![Build Status](https://travis-ci.org/ASIDataScience/sml-sync.svg?branch=master)](https://travis-ci.org/ASIDataScience/sml-sync)
+
 You like writing code on your computer, but want to run the code on
 [SherlockML](https://sherlockml.com). This makes that easier.
 


### PR DESCRIPTION
This sets up Travis CI. At the moment, it just runs pytest. It'd be good to add flake8 when the codebase has been cleaned up.