### PR TITLE
Check code formatting in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
       python:
         - "3.5"
         - "3.6"
+        - "3.7"
     - name: Check formatting
       stage: test
       install:
@@ -20,4 +21,4 @@ jobs:
       script:
         - black --check .
       python:
-        - "3.6"
+        - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - pip install -U pip
   - pip install -r requirements.txt
   - pip install pytest
-script: py.test
+script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: python
 cache: pip
-python:
-  - 3.5
-  - 3.6
 install:
   - pip install -U pip
   - pip install -r requirements.txt
   - pip install pytest
-script: pytest
+jobs:
+  include:
+    - name: Run unit tests
+      stage: test
+      script:
+        - pytest
+      python:
+        - "3.5"
+        - "3.6"
+    - name: Check formatting
+      stage: test
+      install:
+        - pip install black
+      script:
+        - black --check .
+      python:
+        - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-language:
-  python
+language: python
 python:
-  - "3.5"
-  - "3.6"
+  - 3.5
+  - 3.6
 install:
-  - "pip install -U pip"
-  - "pip install -r requirements.txt"
-  - "pip install pytest"
-script:
-  py.test
+  - pip install -U pip
+  - pip install -r requirements.txt
+  - pip install pytest
+script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,21 @@ install:
   - pip install pytest
 jobs:
   include:
-    - name: Run unit tests
+    - name: Run unit tests on Python 3.5 and 3.6
       stage: test
       script:
         - pytest
       python:
         - "3.5"
         - "3.6"
+    - name: Run unit tests on Python 3.7
+      stage: test
+      script:
+        - pytest
+      python:
         - "3.7"
+      dist: xenial
+      sudo: true
     - name: Check formatting
       stage: test
       install:
@@ -22,3 +29,5 @@ jobs:
         - black --check .
       python:
         - "3.7"
+      dist: xenial
+      sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - 3.5
   - 3.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79


### PR DESCRIPTION
* Use preferred pytest executable name: `pytest` is now preferred over `py.test`.
* Enable pip cache on Travis CI to speed up package installation.
* Add `pyproject.toml` configuration file to set Black line length.
* Add Travis job to check formatting with Black.
* Test `sml-sync` against Python 3.7 in addition to 3.5 and 3.6.
