### PR TITLE
Ignore .nfs* files by default

### DIFF
--- a/sml_sync/cli/__init__.py
+++ b/sml_sync/cli/__init__.py
@@ -17,6 +17,7 @@ DEFAULT_IGNORE_PATTERNS = [
     ".git",
     ".mypy_cache",
     ".cache",
+    ".nfs*",
 ]
 
 


### PR DESCRIPTION
These files are used by NFS to achieve delete on last close. Closes #37.