### PR TITLE
Remove `sudo: true` from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ jobs:
       python:
         - "3.7"
       dist: xenial
-      sudo: true
     - name: Check formatting
       stage: test
       install:
@@ -35,4 +34,3 @@ jobs:
       python:
         - "3.7"
       dist: xenial
-      sudo: true


### PR DESCRIPTION
This is no longer necessary due to [recent Travis CI infrastructure updates](https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-is-here!-79690).