### PR TITLE
Bug/prompt toolkit version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "paramiko",
         "watchdog",
         "semantic_version",
-        "prompt_toolkit>=2.0",
+        "prompt_toolkit>=2.0,<3.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
This PR addresses Scott's comment about the version of prompt_toolkit specified in `setup.py`.